### PR TITLE
Fix the URL for loading the sandbox mod

### DIFF
--- a/mod_list.tsv
+++ b/mod_list.tsv
@@ -4,4 +4,4 @@ v0.1	Autumn Chen	https://aucchen.github.io/social_democracy_mods/v0.1.json	The v
 Social Democracy Redux	u/CuttleCraft	https://cuttlecraft.github.io/social_democracy_redux/	A general changes mod that doesn’t stray too far from the base game	1	0
 Two Steps Forward, One Leap Below	Passionario	https://passionario.github.io/2steps_1leap/	Unofficial mod about pushing limits and unwise experimentation	1	0
 LVP Mod	u/originalperson0	https://originn0.github.io/social_democracy_alternate_history/	A mod with merged liberal parties	1	0
-Sandbox	GeneralGoldYT	https://generalgold.github.io/spdmod/	A lot of resources and budget, and you can set party relations	1	0
+Sandbox	GeneralGoldYT	https://spd.generalgoldyt.com/	A lot of resources and budget, and you can set party relations. Also has an optional no end date feature!	1	0


### PR DESCRIPTION
The current URL for the sandbox mod auto-redirects to the custom github pages domain I use, so it doesn't work when being loaded through the base game's mod loader. This commit fixes the URL so it should actually work this time 

(sorry aucchen 😅)